### PR TITLE
Use shell_escape to escape command arguments if necessary to avoid

### DIFF
--- a/lib/tty/command/cmd.rb
+++ b/lib/tty/command/cmd.rb
@@ -42,7 +42,7 @@ module TTY
           else
             @command = sanitize(command)
           end
-          @argv = args.map(&:to_s)
+          @argv = args.map { |i| shell_escape(i) }
         end
         @env ||= {}
         @options = opts
@@ -134,6 +134,18 @@ module TTY
           acc << '; ' if (index + 1) != lines.size
           acc
         end
+      end
+
+      # Enclose s in quotes if it contains characters that require escaping
+      # 
+      # @api private 
+      def shell_escape(s)
+        s = s.to_s
+        if s !~ /^[0-9A-Za-z+,.\/:=@_-]+$/
+          s = s.gsub("'", "'\\''")
+          s = "'#{s}'"
+        end
+        s
       end
     end # Cmd
   end # Command

--- a/spec/unit/cmd_spec.rb
+++ b/spec/unit/cmd_spec.rb
@@ -121,4 +121,12 @@ RSpec.describe TTY::Command::Cmd do
       argv: ['hello']
     })
   end
+
+  it "escapes arguments that need escaping" do
+    cmd = TTY::Command::Cmd.new(:echo, 'hello world')
+    expect(cmd.to_hash).to include({
+      command: 'echo',
+      argv: ["'hello world'"]
+    })
+  end
 end


### PR DESCRIPTION
issues with unusual characters in arguments. Fixes issue #6.