### PR TITLE
bytesize on nil

### DIFF
--- a/lib/tty/command/truncator.rb
+++ b/lib/tty/command/truncator.rb
@@ -102,7 +102,7 @@ module TTY
           dst << value[0...offset]
           value = value[offset..-1]
         end
-        value
+        value.to_s
       end
     end # Truncator
   end # Command

--- a/spec/unit/truncator_spec.rb
+++ b/spec/unit/truncator_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe TTY::Command::Truncator do
     expect(truncator.read).to eq("abcd")
   end
 
+  it "writes more bytes letter" do
+    truncator = described_class.new(max_size: 1000)
+
+    multibytes_string = "’test’"
+
+    expect { truncator.write(multibytes_string) }.to_not raise_error
+    expect(truncator.read).to eq(multibytes_string)
+  end
+
   it "overflows prefix and suffix " do
     truncator = described_class.new(max_size: 2)
 


### PR DESCRIPTION
I have error `NoMethodError: undefined method bytesize for nil:NilClass` on

```ruby
  cmd = TTY::Command.new
  cmd.run "wget http://ftp.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.gz"
```

Problem is that `value[offset..-1]` return nil. Offsett is equal to value size.