### PR TITLE
Update deprecated Fixnum class to Integer for Ruby 2.4 compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ You can directly use shell redirection facility like so:
 cmd.run("ls 1&>2")
 ```
 
-You can provide the streams as additional hash options where the key is one of `:in`, `:out`, `:err`, a fixnum(a file descriptor for the child process), an IO or array. The pair value can be a filename for redirection.
+You can provide the streams as additional hash options where the key is one of `:in`, `:out`, `:err`, an integer (a file descriptor for the child process), an IO or array. The pair value can be a filename for redirection.
 
 ```ruby
 cmd.run(:ls, :in => "/dev/null")   # read mode

--- a/lib/tty/command/execute.rb
+++ b/lib/tty/command/execute.rb
@@ -77,7 +77,7 @@ module TTY
           true
         when ::IO
           true
-        when ::Fixnum
+        when ::Integer
           object >= 0
         when respond_to?(:to_i) && !object.to_io.nil?
           true


### PR DESCRIPTION
This stops the deprecation warnings for Ruby 2.4 (e.g.  /var/lib/gems/2.4.0/gems/tty-command-0.3.2/lib/tty/command/execute.rb:80: warning: constant ::Fixnum is deprecated ), without affecting compatability with older versions of Ruby (as far back as 1.8.6, at least.)

http://blog.bigbinary.com/2016/11/18/ruby-2-4-unifies-fixnum-and-bignum-into-integer.html