### PR TITLE
change print to << to match pretty

### DIFF
--- a/lib/tty/command/printers/quiet.rb
+++ b/lib/tty/command/printers/quiet.rb
@@ -17,7 +17,7 @@ module TTY
         end
 
         def write(message)
-          output.print(message)
+          output << message
         end
       end # Progress
     end # Printers


### PR DESCRIPTION
I created issue #29 to explain this. In short the readme.md file says

> By default the printers log to stdout but this can be changed by passing an object that responds to << message

Also the pretty printer also uses the `<<` message instead of `print`.