### PR TITLE
Handling of timeout even without output

### DIFF
--- a/spec/fixtures/infinite_no_output
+++ b/spec/fixtures/infinite_no_output
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+loop do
+  sleep 5
+end

--- a/spec/unit/timeout_spec.rb
+++ b/spec/unit/timeout_spec.rb
@@ -10,6 +10,17 @@ RSpec.describe TTY::Command, '#run' do
     }.to raise_error(TTY::Command::TimeoutExceeded)
   end
 
+  context "when there is no output" do
+    it "times out after a specified period" do
+      infinite = tmp_path('infinite_no_output')
+      output = StringIO.new
+      cmd = TTY::Command.new(output: output)
+      expect {
+        cmd.run("ruby #{infinite}", timeout: 0.1)
+      }.to raise_error(TTY::Command::TimeoutExceeded)
+    end
+  end
+
   it "times out globally all commands" do
     infinite = tmp_path('infinite')
     output = StringIO.new


### PR DESCRIPTION
This PR handles timeout even when the command ran is not outputting anything.

Closes https://github.com/piotrmurach/tty-command/issues/43