### PR TITLE
Add option to separate `pretty` command output with new line

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Or install it yourself as:
     * [2.3.2. UUID](#232-uuid)
     * [2.3.3. Only output on error](#233-only-output-on-error)
     * [2.3.4. Verbose](#234-verbose)
+    * [2.3.5 Separate commands with newline](#235-separate-commands-with-newline)
   * [2.4. Dry run](#24-dry-run)
   * [2.5. Wait](#25-wait)
   * [2.6. Test](#26-test)
@@ -243,6 +244,22 @@ By default commands will produce warnings when, for example `pty` option is not 
 
 ```ruby
 cmd.run("echo '\e[32mColors!\e[0m'", pty: true, verbose: false)
+```
+
+#### 2.3.5 Separate commands with newline
+
+Setting `:separate_commands_with_newline` to `true` prints an empty line between `:pretty` command outputs:
+
+```ruby
+cmd = TTY::Command.new(separate_commands_with_newline: true)
+cmd.run('rm -f file_1') && cmd.run('rm -f file_2')
+# =>
+# [5d90db5d] Running rm -f file_1
+# [5d90db5d] Finished in 0.013 seconds with exit status 0 (successful)
+# 
+# [e8114d68] Running rm -f file_2
+# [e8114d68] Finished in 0.007 seconds with exit status 0 (successful)
+# 
 ```
 
 ### 2.4 Dry run

--- a/lib/tty/command.rb
+++ b/lib/tty/command.rb
@@ -55,9 +55,10 @@ module TTY
       @output = options.fetch(:output) { $stdout }
       @color   = options.fetch(:color) { true }
       @uuid    = options.fetch(:uuid) { true }
+      @separate_commands_with_newline = options.fetch(:separate_commands_with_newline) { false }
       @printer_name = options.fetch(:printer) { :pretty }
       @dry_run = options.fetch(:dry_run) { false }
-      @printer = use_printer(@printer_name, color: @color, uuid: @uuid)
+      @printer = use_printer(@printer_name, color: @color, uuid: @uuid, separate_commands_with_newline: @separate_commands_with_newline)
       @cmd_options = {}
       @cmd_options[:verbose] = options.fetch(:verbose, true)
       @cmd_options[:pty] = true if options[:pty]

--- a/lib/tty/command/printers/pretty.rb
+++ b/lib/tty/command/printers/pretty.rb
@@ -38,6 +38,7 @@ module TTY
           message << " with exit status #{status}" if status
           message << " (#{success_or_failure(status)})"
           write(cmd, message.join, cmd.uuid)
+          output << "\n" if options.fetch(:separate_commands_with_newline) { false }
         end
 
         # Write message out to output

--- a/spec/unit/printers/pretty_spec.rb
+++ b/spec/unit/printers/pretty_spec.rb
@@ -169,4 +169,15 @@ RSpec.describe TTY::Command::Printers::Pretty do
       "[\e[32maaaaaa\e[0m] Finished in x seconds with exit status 1 (\e[31;1mfailed\e[0m)\n"
     ])
   end
+
+  it "prints new line after command output if separate_commands_with_newline is true" do
+    allow(SecureRandom).to receive(:uuid).and_return(uuid)
+    printer = TTY::Command::Printers::Pretty.new(output, separate_commands_with_newline: true)
+    cmd = TTY::Command::Cmd.new(:echo, 'hello')
+
+    printer.print_command_exit(cmd, 0, 5.321)
+    output.rewind
+
+    expect(output.string).to end_with("\n\n")
+  end
 end


### PR DESCRIPTION
I found this style of output to be more readable.

![screen shot 2018-04-24 at 17 50 33](https://user-images.githubusercontent.com/3299948/39198715-0a18ec18-47e8-11e8-9a29-38a72aae2039.png)

I made an [implementation](https://github.com/thisismydesign/autowow/blob/a502380dbeaaead232ad5c34e3789b0229d62d7c/lib/autowow/executor.rb#L21-L29) hijacking your printer classes but that wasn't a smart thing to do (https://github.com/thisismydesign/autowow/issues/13). As an alternative I'm wondering whether you would accept such an option?

This is just a quick draft, todo:
- [ ] decide whether it makes sense to add this to other printers / communicate better that it only works with `pretty`
- [ ] make it work both with initialize params and command params  (i'm not sure if that's the case atm)