### PR TITLE
fix Ruby 2.7 warning: Using the last argument as keyword parameters i…

### DIFF
--- a/lib/tty/command.rb
+++ b/lib/tty/command.rb
@@ -174,7 +174,7 @@ module TTY
     # @api private
     def command(*args)
       cmd = Cmd.new(*args)
-      cmd.update(@cmd_options)
+      cmd.update(**@cmd_options)
       cmd
     end
 


### PR DESCRIPTION

### Describe the change
Ruby 2.7 warning: "Using the last argument as keyword parameters is deprecated"

### Why are we doing this?
In Ruby 2.7, the way ruby handles the positional arguments and keyword arguments is changed, aiming to provide a smooth transition to Ruby 3. This has resulted in warnings on the command line when one uses cmd.run.

### Benefits
This will remove the warning message which is thrown

### Drawbacks
* Doesn't seem a very elegant way of doing this
* I am not sure if there's a better way to add this or there are more places where this is needed.

### Requirements
Put an X between brackets on each line if you have done the item:
[] Tests written & passing locally?
[] Code style checked?
[] Rebased with `master` branch?
[] Documentation updated?
