### PR TITLE
Update to release notes and bump version to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Change log
 
-## [v0.10.0] - 2020-07-xx
+## [v0.10.0] - 2020-08-11
 
 ### Changed
 * Change :chdir option to escape directory location path
 * Change gemspec to add metadata and remove test artefacts
+* Change pastel dependency version to `0.8`
 
 ### Fixed
 * Fix Ruby 2.7 keyword conversion errors
 * Fix error when environment variable contains % character
+* Fix Ruby 2.7 keyword parameter warning when calling `cmd.run`
 
 ## [v0.9.0] - 2019-09-28
 

--- a/lib/tty/command/version.rb
+++ b/lib/tty/command/version.rb
@@ -2,6 +2,6 @@
 
 module TTY
   class Command
-    VERSION = '0.9.0'
+    VERSION = '0.10.0'
   end # Command
 end # TTY

--- a/lib/tty/command/version.rb
+++ b/lib/tty/command/version.rb
@@ -2,6 +2,6 @@
 
 module TTY
   class Command
-    VERSION = '0.10.0'
+    VERSION = "0.10.0"
   end # Command
 end # TTY


### PR DESCRIPTION
### Describe the change

Release notes have been updated to include the following commits:

- [fix Ruby 2.7 warning: Using the last argument as keyword parameters is deprecated](https://github.com/piotrmurach/tty-command/commit/e7fb8c327ce891f839eafe555e68b08ae2149010)
- [Change to update pastel dependency and restrict version to minor version only](https://github.com/piotrmurach/tty-command/commit/dab9650a541f12e31ce33408f328b2a7b1073a64)

`tty-command` version is bumped to `0.10.0`. 

### Why are we doing this?

This release updates the `pastel` gem to version `0.8.0`. This fixes the `pastel` dependency problem encountered when trying to use `tty-command` version `0.22.0` and `tty-command` version `0.9.0`.

### Benefits

New release with bug fixes and updated dependencies.

### Drawbacks

None

### Requirements

Put an X between brackets on each line if you have done the item:

- [X] Tests ~written &~ passing locally.
- [X] Code style checked
- [X] Rebased with `master` branch.
- [X] Documentation updated.
