### PR TITLE
Fix Ruby 3.0 failure from double splat operator

### DIFF
--- a/lib/tty/command.rb
+++ b/lib/tty/command.rb
@@ -51,7 +51,7 @@ module TTY
     #   the mode for executing command
     #
     # @api public
-    def initialize(**options)
+    def initialize(options)
       @output = options.fetch(:output) { $stdout }
       @color   = options.fetch(:color) { true }
       @uuid    = options.fetch(:uuid) { true }

--- a/lib/tty/command.rb
+++ b/lib/tty/command.rb
@@ -51,7 +51,7 @@ module TTY
     #   the mode for executing command
     #
     # @api public
-    def initialize(options)
+    def initialize(options = {})
       @output = options.fetch(:output) { $stdout }
       @color   = options.fetch(:color) { true }
       @uuid    = options.fetch(:uuid) { true }

--- a/spec/unit/command_spec.rb
+++ b/spec/unit/command_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe TTY::Command, "::new" do
+  it "allows initializing with a params hash" do
+    expect { TTY::Command.new({}) }.to_not raise_error
+  end
+end

--- a/spec/unit/input_spec.rb
+++ b/spec/unit/input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe TTY::Command, "input" do
     output = StringIO.new
     command = TTY::Command.new(output: output)
 
-    out, = command.run("ruby #{cli}", input: "Piotr\n")
+    out, = command.run('ruby', "#{cli}", input: "Piotr\n")
 
     expect(out.chomp).to eq("Your name: Piotr")
   end

--- a/spec/unit/input_spec.rb
+++ b/spec/unit/input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe TTY::Command, "input" do
     output = StringIO.new
     command = TTY::Command.new(output: output)
 
-    out, = command.run('ruby', "#{cli}", input: "Piotr\n")
+    out, = command.run(:ruby, cli, input: "Piotr\n")
 
     expect(out.chomp).to eq("Your name: Piotr")
   end

--- a/spec/unit/printers/pretty_spec.rb
+++ b/spec/unit/printers/pretty_spec.rb
@@ -109,9 +109,9 @@ RSpec.describe TTY::Command::Printers::Pretty do
     lines.each { |line| line.gsub!(/\d+\.\d+(?= seconds)/, "x") }
 
     expect(lines).to eq([
-      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{zero_exit}\e[0m\n",
+      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{Shellwords.escape(zero_exit)}\e[0m\n",
       "[\e[32maaaaaa\e[0m] Finished in x seconds with exit status 0 (\e[32;1msuccessful\e[0m)\n",
-      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{zero_exit}\e[0m\n",
+      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{Shellwords.escape(zero_exit)}\e[0m\n",
       "[\e[32maaaaaa\e[0m] \tyess\n",
       "[\e[32maaaaaa\e[0m] Finished in x seconds with exit status 0 (\e[32;1msuccessful\e[0m)\n"
     ])
@@ -132,10 +132,10 @@ RSpec.describe TTY::Command::Printers::Pretty do
     lines.each { |line| line.gsub!(/\d+\.\d+(?= seconds)/, "x") }
 
     expect(lines).to eq([
-      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{non_zero_exit}\e[0m\n",
+      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{Shellwords.escape(non_zero_exit)}\e[0m\n",
       "[\e[32maaaaaa\e[0m] \tnooo\n",
       "[\e[32maaaaaa\e[0m] Finished in x seconds with exit status 1 (\e[31;1mfailed\e[0m)\n",
-      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{non_zero_exit}\e[0m\n",
+      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{Shellwords.escape(non_zero_exit)}\e[0m\n",
       "[\e[32maaaaaa\e[0m] \tnooo\n",
       "[\e[32maaaaaa\e[0m] Finished in x seconds with exit status 1 (\e[31;1mfailed\e[0m)\n"
     ])
@@ -161,10 +161,10 @@ RSpec.describe TTY::Command::Printers::Pretty do
     lines.each { |line| line.gsub!(/\d+\.\d+(?= seconds)/, "x") }
 
     expect(lines).to eq([
-      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{non_zero_exit}\e[0m\n",
+      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{Shellwords.escape(non_zero_exit)}\e[0m\n",
       "[\e[32maaaaaa\e[0m] \tnooo\n",
       "[\e[32maaaaaa\e[0m] Finished in x seconds with exit status 1 (\e[31;1mfailed\e[0m)\n",
-      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{non_zero_exit}\e[0m\n",
+      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{Shellwords.escape(non_zero_exit)}\e[0m\n",
       "[\e[32maaaaaa\e[0m] \tnooo\n",
       "[\e[32maaaaaa\e[0m] Finished in x seconds with exit status 1 (\e[31;1mfailed\e[0m)\n"
     ])

--- a/spec/unit/printers/pretty_spec.rb
+++ b/spec/unit/printers/pretty_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe TTY::Command::Printers::Pretty do
 
   it "doesn't print output on success when only_output_on_error is true" do
     zero_exit = fixtures_path("zero_exit")
+    escaped_path = Shellwords.escape(zero_exit)
     allow(SecureRandom).to receive(:uuid).and_return(uuid)
     printer = TTY::Command::Printers::Pretty
     cmd = TTY::Command.new(output: output, printer: printer)
@@ -109,9 +110,9 @@ RSpec.describe TTY::Command::Printers::Pretty do
     lines.each { |line| line.gsub!(/\d+\.\d+(?= seconds)/, "x") }
 
     expect(lines).to eq([
-      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{Shellwords.escape(zero_exit)}\e[0m\n",
+      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{escaped_path}\e[0m\n",
       "[\e[32maaaaaa\e[0m] Finished in x seconds with exit status 0 (\e[32;1msuccessful\e[0m)\n",
-      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{Shellwords.escape(zero_exit)}\e[0m\n",
+      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{escaped_path}\e[0m\n",
       "[\e[32maaaaaa\e[0m] \tyess\n",
       "[\e[32maaaaaa\e[0m] Finished in x seconds with exit status 0 (\e[32;1msuccessful\e[0m)\n"
     ])
@@ -119,6 +120,7 @@ RSpec.describe TTY::Command::Printers::Pretty do
 
   it "prints output on error & raises ExitError when only_output_on_error is true" do
     non_zero_exit = fixtures_path("non_zero_exit")
+    escaped_path = Shellwords.escape(non_zero_exit)
     allow(SecureRandom).to receive(:uuid).and_return(uuid)
     printer = TTY::Command::Printers::Pretty
     cmd = TTY::Command.new(output: output, printer: printer)
@@ -132,10 +134,10 @@ RSpec.describe TTY::Command::Printers::Pretty do
     lines.each { |line| line.gsub!(/\d+\.\d+(?= seconds)/, "x") }
 
     expect(lines).to eq([
-      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{Shellwords.escape(non_zero_exit)}\e[0m\n",
+      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{escaped_path}\e[0m\n",
       "[\e[32maaaaaa\e[0m] \tnooo\n",
       "[\e[32maaaaaa\e[0m] Finished in x seconds with exit status 1 (\e[31;1mfailed\e[0m)\n",
-      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{Shellwords.escape(non_zero_exit)}\e[0m\n",
+      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{escaped_path}\e[0m\n",
       "[\e[32maaaaaa\e[0m] \tnooo\n",
       "[\e[32maaaaaa\e[0m] Finished in x seconds with exit status 1 (\e[31;1mfailed\e[0m)\n"
     ])
@@ -143,6 +145,7 @@ RSpec.describe TTY::Command::Printers::Pretty do
 
   it "prints output on error when only_output_on_error is true" do
     non_zero_exit = fixtures_path("non_zero_exit")
+    escaped_path = Shellwords.escape(non_zero_exit)
     allow(SecureRandom).to receive(:uuid).and_return(uuid)
     printer = TTY::Command::Printers::Pretty
     cmd = TTY::Command.new(output: output, printer: printer)
@@ -161,10 +164,10 @@ RSpec.describe TTY::Command::Printers::Pretty do
     lines.each { |line| line.gsub!(/\d+\.\d+(?= seconds)/, "x") }
 
     expect(lines).to eq([
-      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{Shellwords.escape(non_zero_exit)}\e[0m\n",
+      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{escaped_path}\e[0m\n",
       "[\e[32maaaaaa\e[0m] \tnooo\n",
       "[\e[32maaaaaa\e[0m] Finished in x seconds with exit status 1 (\e[31;1mfailed\e[0m)\n",
-      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{Shellwords.escape(non_zero_exit)}\e[0m\n",
+      "[\e[32maaaaaa\e[0m] Running \e[33;1mruby #{escaped_path}\e[0m\n",
       "[\e[32maaaaaa\e[0m] \tnooo\n",
       "[\e[32maaaaaa\e[0m] Finished in x seconds with exit status 1 (\e[31;1mfailed\e[0m)\n"
     ])

--- a/spec/unit/pty_spec.rb
+++ b/spec/unit/pty_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TTY::Command, ":pty" do
     output = StringIO.new
     cmd = TTY::Command.new(output: output, pty: true)
 
-    out, err = cmd.run(color_cli)
+    out, err = cmd.run(Shellwords.escape(color_cli))
 
     expect(err).to eq("")
     expect(out).to eq("\e[32mcolored\e[0m\n")
@@ -19,7 +19,7 @@ RSpec.describe TTY::Command, ":pty" do
     output = StringIO.new
     cmd = TTY::Command.new(output: output)
 
-    out, err = cmd.run(color_cli, pty: true)
+    out, err = cmd.run(Shellwords.escape(color_cli), pty: true)
 
     expect(err).to eq("")
     expect(out).to eq("\e[32mcolored\e[0m\n")
@@ -33,7 +33,7 @@ RSpec.describe TTY::Command, ":pty" do
     output = StringIO.new
     cmd = TTY::Command.new(output: output)
 
-    out, err = cmd.run("ruby #{phased_output}", pty: true)
+    out, err = cmd.run('ruby', "#{phased_output}", pty: true)
 
     expect(out).to eq("." * 10)
     expect(err).to eq("")
@@ -42,7 +42,7 @@ RSpec.describe TTY::Command, ":pty" do
     lines = output.readlines
     lines.last.gsub!(/\d+\.\d+/, "x")
     expect(lines).to eq([
-      "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{phased_output}\e[0m\n",
+      "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{Shellwords.escape(phased_output)}\e[0m\n",
       "[\e[32m#{uuid}\e[0m] \t.\n",
       "[\e[32m#{uuid}\e[0m] \t.\n",
       "[\e[32m#{uuid}\e[0m] \t.\n",

--- a/spec/unit/pty_spec.rb
+++ b/spec/unit/pty_spec.rb
@@ -28,12 +28,13 @@ RSpec.describe TTY::Command, ":pty" do
   it "logs phased output in pseudo terminal mode",
       unless: RSpec::Support::OS.windows? do
     phased_output = fixtures_path("phased_output")
+    escaped_path = Shellwords.escape(phased_output)
     uuid = "xxxx"
     allow(SecureRandom).to receive(:uuid).and_return(uuid)
     output = StringIO.new
     cmd = TTY::Command.new(output: output)
 
-    out, err = cmd.run('ruby', "#{phased_output}", pty: true)
+    out, err = cmd.run(:ruby, phased_output, pty: true)
 
     expect(out).to eq("." * 10)
     expect(err).to eq("")
@@ -42,7 +43,7 @@ RSpec.describe TTY::Command, ":pty" do
     lines = output.readlines
     lines.last.gsub!(/\d+\.\d+/, "x")
     expect(lines).to eq([
-      "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{Shellwords.escape(phased_output)}\e[0m\n",
+      "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{escaped_path}\e[0m\n",
       "[\e[32m#{uuid}\e[0m] \t.\n",
       "[\e[32m#{uuid}\e[0m] \t.\n",
       "[\e[32m#{uuid}\e[0m] \t.\n",

--- a/spec/unit/run_spec.rb
+++ b/spec/unit/run_spec.rb
@@ -82,18 +82,19 @@ RSpec.describe TTY::Command, "#run" do
 
   it "runs command and fails with logging" do
     non_zero_exit = fixtures_path("non_zero_exit")
+    escaped_path = Shellwords.escape(non_zero_exit)
     output = StringIO.new
     uuid = "xxxx"
     allow(SecureRandom).to receive(:uuid).and_return(uuid)
     command = TTY::Command.new(output: output)
 
-    command.run!('ruby', "#{non_zero_exit}")
+    command.run!(:ruby, non_zero_exit)
 
     output.rewind
     lines = output.readlines
     lines.last.gsub!(/\d+\.\d+/, "x")
     expect(lines).to eq([
-      "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{Shellwords.escape(non_zero_exit)}\e[0m\n",
+      "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{escaped_path}\e[0m\n",
       "[\e[32m#{uuid}\e[0m] \tnooo\n",
       "[\e[32m#{uuid}\e[0m] Finished in x seconds with exit status 1 " \
       "(\e[31;1mfailed\e[0m)\n"
@@ -106,7 +107,7 @@ RSpec.describe TTY::Command, "#run" do
     command = TTY::Command.new(output: output)
 
     expect {
-      command.run('ruby', "#{non_zero_exit}")
+      command.run(:ruby, non_zero_exit)
     }.to raise_error(TTY::Command::ExitError, [
       "Running `ruby #{Shellwords.escape(non_zero_exit)}` failed with",
       "  exit status: 1",
@@ -122,7 +123,7 @@ RSpec.describe TTY::Command, "#run" do
     output = []
     error = []
 
-    command.run('ruby', "#{stream}") do |out, err|
+    command.run(:ruby, stream) do |out, err|
       output << out if out
       error << err if err
     end
@@ -143,12 +144,13 @@ RSpec.describe TTY::Command, "#run" do
 
   it "logs phased output in one line" do
     phased_output = fixtures_path("phased_output")
+    escaped_path = Shellwords.escape(phased_output)
     uuid = "xxxx"
     allow(SecureRandom).to receive(:uuid).and_return(uuid)
     output = StringIO.new
     cmd = TTY::Command.new(output: output)
 
-    out, err = cmd.run('ruby', "#{phased_output}")
+    out, err = cmd.run(:ruby, phased_output)
 
     expect(out).to eq("." * 10)
     expect(err).to eq("")
@@ -157,7 +159,7 @@ RSpec.describe TTY::Command, "#run" do
     lines = output.readlines
     lines.last.gsub!(/\d+\.\d+/, "x")
     expect(lines).to eq([
-      "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{Shellwords.escape(phased_output)}\e[0m\n",
+      "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{escaped_path}\e[0m\n",
       "[\e[32m#{uuid}\e[0m] \t..........\n",
       "[\e[32m#{uuid}\e[0m] Finished in x seconds with exit status 0 " \
       "(\e[32;1msuccessful\e[0m)\n"

--- a/spec/unit/run_spec.rb
+++ b/spec/unit/run_spec.rb
@@ -87,13 +87,13 @@ RSpec.describe TTY::Command, "#run" do
     allow(SecureRandom).to receive(:uuid).and_return(uuid)
     command = TTY::Command.new(output: output)
 
-    command.run!("ruby #{non_zero_exit}")
+    command.run!('ruby', "#{non_zero_exit}")
 
     output.rewind
     lines = output.readlines
     lines.last.gsub!(/\d+\.\d+/, "x")
     expect(lines).to eq([
-      "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{non_zero_exit}\e[0m\n",
+      "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{Shellwords.escape(non_zero_exit)}\e[0m\n",
       "[\e[32m#{uuid}\e[0m] \tnooo\n",
       "[\e[32m#{uuid}\e[0m] Finished in x seconds with exit status 1 " \
       "(\e[31;1mfailed\e[0m)\n"
@@ -106,9 +106,9 @@ RSpec.describe TTY::Command, "#run" do
     command = TTY::Command.new(output: output)
 
     expect {
-      command.run("ruby #{non_zero_exit}")
+      command.run('ruby', "#{non_zero_exit}")
     }.to raise_error(TTY::Command::ExitError, [
-      "Running `ruby #{non_zero_exit}` failed with",
+      "Running `ruby #{Shellwords.escape(non_zero_exit)}` failed with",
       "  exit status: 1",
       "  stdout: nooo",
       "  stderr: Nothing written\n"
@@ -122,7 +122,7 @@ RSpec.describe TTY::Command, "#run" do
     output = []
     error = []
 
-    command.run("ruby #{stream}") do |out, err|
+    command.run('ruby', "#{stream}") do |out, err|
       output << out if out
       error << err if err
     end
@@ -148,7 +148,7 @@ RSpec.describe TTY::Command, "#run" do
     output = StringIO.new
     cmd = TTY::Command.new(output: output)
 
-    out, err = cmd.run("ruby #{phased_output}")
+    out, err = cmd.run('ruby', "#{phased_output}")
 
     expect(out).to eq("." * 10)
     expect(err).to eq("")
@@ -157,7 +157,7 @@ RSpec.describe TTY::Command, "#run" do
     lines = output.readlines
     lines.last.gsub!(/\d+\.\d+/, "x")
     expect(lines).to eq([
-      "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{phased_output}\e[0m\n",
+      "[\e[32m#{uuid}\e[0m] Running \e[33;1mruby #{Shellwords.escape(phased_output)}\e[0m\n",
       "[\e[32m#{uuid}\e[0m] \t..........\n",
       "[\e[32m#{uuid}\e[0m] Finished in x seconds with exit status 0 " \
       "(\e[32;1msuccessful\e[0m)\n"

--- a/spec/unit/timeout_spec.rb
+++ b/spec/unit/timeout_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TTY::Command, "#run" do
     cmd = TTY::Command.new(output: output)
 
     expect {
-      cmd.run("ruby #{infinite}", timeout: 0.1)
+      cmd.run('ruby', "#{infinite}", timeout: 0.1)
     }.to raise_error(TTY::Command::TimeoutExceeded)
   end
 
@@ -17,7 +17,7 @@ RSpec.describe TTY::Command, "#run" do
     cmd = TTY::Command.new(output: output, timeout: 0.1)
 
     expect {
-      cmd.run("ruby #{infinite}")
+      cmd.run('ruby', "#{infinite}")
     }.to raise_error(TTY::Command::TimeoutExceeded)
   end
 
@@ -30,7 +30,7 @@ RSpec.describe TTY::Command, "#run" do
     infinite_input = range.lazy.map { |_x| "hello" }.first(100).join("\n")
 
     expect {
-      cmd.run("ruby #{cli}", input: infinite_input, timeout: 0.1)
+      cmd.run('ruby', "#{cli}", input: infinite_input, timeout: 0.1)
     }.to raise_error(TTY::Command::TimeoutExceeded)
   end
 end

--- a/spec/unit/timeout_spec.rb
+++ b/spec/unit/timeout_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TTY::Command, "#run" do
     cmd = TTY::Command.new(output: output)
 
     expect {
-      cmd.run('ruby', "#{infinite}", timeout: 0.1)
+      cmd.run(:ruby, infinite, timeout: 0.1)
     }.to raise_error(TTY::Command::TimeoutExceeded)
   end
 
@@ -17,7 +17,7 @@ RSpec.describe TTY::Command, "#run" do
     cmd = TTY::Command.new(output: output, timeout: 0.1)
 
     expect {
-      cmd.run('ruby', "#{infinite}")
+      cmd.run(:ruby, infinite)
     }.to raise_error(TTY::Command::TimeoutExceeded)
   end
 
@@ -30,7 +30,7 @@ RSpec.describe TTY::Command, "#run" do
     infinite_input = range.lazy.map { |_x| "hello" }.first(100).join("\n")
 
     expect {
-      cmd.run('ruby', "#{cli}", input: infinite_input, timeout: 0.1)
+      cmd.run(:ruby, cli, input: infinite_input, timeout: 0.1)
     }.to raise_error(TTY::Command::TimeoutExceeded)
   end
 end


### PR DESCRIPTION
### Describe the change

This PR fixes a Ruby 3.0 failure (warning in Ruby 2.7) when using double splat operator/keyword params similar to this fix:
https://github.com/piotrmurach/tty-command/commit/5f422f89dd4dbfa96ca849cf5f9dcc6cac8b19e8

When using Ruby 3+ on `tty`, we'll encounter this error (in `tty-command`) trying to make a new app:
```
$ teletype new my_app      
/Users/justin.gaylor/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/tty-command-0.9.0/lib/tty/command.rb:54:in `initialize': wrong number of arguments (given 1, expected 0) (ArgumentError)
	from /Users/justin.gaylor/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/tty-0.10.0/lib/tty/cmd.rb:33:in `new'
	from /Users/justin.gaylor/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/tty-0.10.0/lib/tty/cmd.rb:33:in `command'
	from /Users/justin.gaylor/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/tty-0.10.0/lib/tty/commands/new.rb:46:in `initialize'
	from /Users/justin.gaylor/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/tty-0.10.0/lib/tty/cli.rb:128:in `new'
	from /Users/justin.gaylor/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/tty-0.10.0/lib/tty/cli.rb:128:in `new'
	from /Users/justin.gaylor/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
	from /Users/justin.gaylor/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/justin.gaylor/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
	from /Users/justin.gaylor/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
	from /Users/justin.gaylor/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/tty-0.10.0/exe/teletype:14:in `<top (required)>'
	from /Users/justin.gaylor/.asdf/installs/ruby/3.0.3/bin/teletype:25:in `load'
	from /Users/justin.gaylor/.asdf/installs/ruby/3.0.3/bin/teletype:25:in `<main>'
```

By fixing this issue in `tty-command` and bumping the version in `tty`, hopefully we'll be a step closer to being able to use `tty` with Ruby 3+. (There is a separate `"`*': negative argument (ArgumentError)"` issue that happens in `tty` after this is fixed, so I will look into that after this gem gets fixed up.)

For further on the exact issue, read [here](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/). 

Also, unit tests also were updated for a separate issue. When there is a space in the path to the checked out repo base, specs fail due to `TTY::Command` invoking ruby scripts in numerous places without shell escaping. This is fixed so specs will run for everybody.

### Why are we doing this?

`tty-command` doesn't work on Ruby 3.0 or higher.

### Benefits

We can more easily move `tty-command` (and thus the greater `tty` toolkit) forward to Ruby 3! 🚀 

### Drawbacks

None.

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [X] Tests written & passing locally?
- [ ] Code style checked?
- [X] Rebased with `master` branch?
- [X] Documentation updated?
- [ ] Changelog updated?
